### PR TITLE
Add equivalent policy support for encrypt mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCE_FILES
     src/marking.cc
     src/spif.cc
     src/tag.cc
-    src/tagset.cc include/spiffing/spiffing.h src/spiffing.cc)
+    src/tagset.cc include/spiffing/spiffing.h src/spiffing.cc src/equivclass.cc include/spiffing/equivclass.h src/equivcat.cc include/spiffing/equivcat.h src/constants.cc src/constants.h)
 include_directories(include)
 include_directories(deps/rapidxml)
 add_library(spiffing ${SOURCE_FILES})

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ tests: test spifflicator transpifferizer
 	@echo "Coverage test"
 	@$(MAKE) coverage
 	@echo "CLang test"
-	@../llvm/tools/clang/tools/scan-build/scan-build -o report/clang --use-analyzer=../llvm-build/Debug+Asserts/bin/clang make SPIFFINGBUILD=tmp-analyzer tmp-analyzer/libspiffing.a
+	@../llvm/tools/clang/tools/scan-build/scan-build -o report/clang --use-analyzer=../llvm-build/bin/clang make SPIFFINGBUILD=tmp-analyzer tmp-analyzer/libspiffing.a
 	@rm -rf tmp-analyzer
 
 quick-tests: test transpifferizer
@@ -61,7 +61,7 @@ GENBEROBJS=$(GENBERSOURCE:.c=.o)
 SPIFFINGSOURCE=$(wildcard src/*.cc)
 SPIFFINGOBJS=$(SPIFFINGSOURCE:src/%.cc=$(SPIFFINGBUILD)/spiffing/%.o)
 
-#DEBUG?=-g --coverage #-fprofile-dir=./build/ #-fprofile-generate=./build/ #-DEMIT_ASN_DEBUG=1
+DEBUG?=-g --coverage #-fprofile-dir=./build/ #-fprofile-generate=./build/ #-DEMIT_ASN_DEBUG=1
 CXXFLAGS=-std=c++11
 
 gen-ber/.marker: ESSSecurityLabel.asn Clearance.asn acp145.asn SSLPrivileges.asn MissiSecurityCategories.asn

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GENBEROBJS=$(GENBERSOURCE:.c=.o)
 SPIFFINGSOURCE=$(wildcard src/*.cc)
 SPIFFINGOBJS=$(SPIFFINGSOURCE:src/%.cc=$(SPIFFINGBUILD)/spiffing/%.o)
 
-DEBUG?=-g --coverage #-fprofile-dir=./build/ #-fprofile-generate=./build/ #-DEMIT_ASN_DEBUG=1
+#DEBUG?=-g --coverage #-fprofile-dir=./build/ #-fprofile-generate=./build/ #-DEMIT_ASN_DEBUG=1
 CXXFLAGS=-std=c++11
 
 gen-ber/.marker: ESSSecurityLabel.asn Clearance.asn acp145.asn SSLPrivileges.asn MissiSecurityCategories.asn
@@ -96,8 +96,8 @@ submake: build/libspiffing-asn.a
 	@echo Done
 
 gen-ber/%.o: gen-ber/%.c
-	@echo [CC] $@
-	@$(CC) $(DEBUG) -c -o $@ -Igen-ber/ $^
+	@echo [CC PIC] $@
+	@$(CC) -fPIC $(DEBUG) -c -o $@ -Igen-ber/ $^
 
 clean:
 	@echo [CLEAN]
@@ -121,9 +121,9 @@ clearance-parser: build/clearance-parser.o build/libspiffing-asn.a
 	@$(CC) $(DEBUG) -o $@ -Lbuild/ $< -lspiffing-asn
 
 $(SPIFFINGBUILD)/spiffing/%.o: src/%.cc gen-ber/ANY.h
-	@echo [C++] $@
+	@echo [C++ PIC] $@
 	@mkdir -p $(dir $@)
-	@$(CXX) $(DEBUG) $(CXXFLAGS) -Iinclude/ -Igen-ber/ -Ideps/rapidxml/ -o $@ -MD -MF $(@:%.o=%.d) -c $<
+	@$(CXX) -fPIC $(DEBUG) $(CXXFLAGS) -Iinclude/ -Igen-ber/ -Ideps/rapidxml/ -o $@ -MD -MF $(@:%.o=%.d) -c $<
 
 $(SPIFFINGBUILD)/%.o: %.cc
 	@echo [C++] $@

--- a/include/spiffing/category.h
+++ b/include/spiffing/category.h
@@ -32,6 +32,7 @@ SOFTWARE.
 #include <string>
 #include <set>
 #include <memory>
+#include <map>
 
 namespace Spiffing {
     class Category {
@@ -55,6 +56,7 @@ namespace Spiffing {
         void excluded(Classification const & c);
         void excluded(std::unique_ptr<CategoryData> && cd);
         void required(std::unique_ptr<CategoryGroup> && cg);
+        void encryptEquiv(std::shared_ptr<EquivCat> const & equiv);
 
         bool hasMarking() const {
           return m_marking != nullptr;
@@ -65,6 +67,7 @@ namespace Spiffing {
         void marking(std::unique_ptr<Marking> && m) {
           m_marking = std::move(m);
         }
+        void encrypt(Label & label, std::string const & policy_id) const;
 
     private:
         Lacv m_lacv;
@@ -75,6 +78,7 @@ namespace Spiffing {
         std::set<std::unique_ptr<CategoryGroup>> m_required;
         std::set<std::unique_ptr<CategoryData>> m_excluded;
         std::unique_ptr<Marking> m_marking;
+        std::multimap<std::string, std::shared_ptr<EquivCat>> m_encryptEquivs;
     };
 }
 

--- a/include/spiffing/categorydata.h
+++ b/include/spiffing/categorydata.h
@@ -41,6 +41,7 @@ namespace Spiffing {
 
     void compile(Spif const &);
     bool matches(Label const &) const;
+    void fixup(Label &) const;
   private:
     std::set<CategoryRef> m_cats;
     std::string m_tagSetRef;

--- a/include/spiffing/categorygroup.h
+++ b/include/spiffing/categorygroup.h
@@ -27,6 +27,7 @@ SOFTWARE.
 #define SPIFFING_CATEGORYGROUP_H
 
 #include <spiffing/constants.h>
+#include <spiffing/categorydata.h>
 
 #include <set>
 #include <memory>
@@ -41,6 +42,7 @@ namespace Spiffing {
     void compile(Spif const & spif);
 
     void addCategoryData(std::unique_ptr<CategoryData> &&);
+    void fixup(Label & l) const;
   private:
     std::set<std::unique_ptr<CategoryData>> m_categoryData;
     OperationType m_opType;

--- a/include/spiffing/classification.h
+++ b/include/spiffing/classification.h
@@ -36,8 +36,6 @@ namespace Spiffing {
 	class Classification {
 	public:
 		Classification(lacv_t lacv, std::string const & name, unsigned long hierarchy, bool obsolete=false);
-		void colour(std::string const &);
-		std::string const & color() const;
 		bool operator < (Classification const &) const;
 
 		lacv_t lacv() const {
@@ -59,9 +57,17 @@ namespace Spiffing {
 		Marking const & marking(std::unique_ptr<Marking> && m) {
 			m_marking = std::move(m);
 		}
+		std::string const & fgcolour() const {
+			return m_fgcolour;
+		}
+		std::string const & fgcolour(std::string const & c) {
+			m_fgcolour = c;
+			return m_fgcolour;
+		}
 	private:
 		lacv_t m_lacv;
 		std::string const m_name;
+		std::string m_fgcolour;
 		unsigned long m_hierarchy;
 		bool m_obsolete;
 		std::set<std::unique_ptr<CategoryGroup>> m_reqCats;

--- a/include/spiffing/classification.h
+++ b/include/spiffing/classification.h
@@ -28,8 +28,10 @@ SOFTWARE.
 
 #include <spiffing/constants.h>
 #include <spiffing/marking.h>
+#include <spiffing/equivclass.h>
 #include <string>
 #include <set>
+#include <map>
 #include <memory>
 
 namespace Spiffing {
@@ -44,7 +46,7 @@ namespace Spiffing {
 		std::string const & name() const {
 			return m_name;
 		}
-		void addRequiredCategory(std::unique_ptr<CategoryGroup> reqCats);
+		void addRequiredCategory(std::unique_ptr<CategoryGroup> && reqCats);
 		void compile(Spif const &);
 		bool valid(Label const &) const;
 
@@ -64,6 +66,11 @@ namespace Spiffing {
 			m_fgcolour = c;
 			return m_fgcolour;
 		}
+
+		void equivEncrypt(std::shared_ptr<EquivClassification> const & equiv);
+		void equivDecrypt(std::shared_ptr<EquivClassification> const & equiv);
+		std::unique_ptr<Label> encrypt(Label const &, std::string const &) const;
+		std::unique_ptr<Label> decrypt(Label const &) const;
 	private:
 		lacv_t m_lacv;
 		std::string const m_name;
@@ -72,6 +79,8 @@ namespace Spiffing {
 		bool m_obsolete;
 		std::set<std::unique_ptr<CategoryGroup>> m_reqCats;
 		std::unique_ptr<Marking> m_marking;
+		std::map<std::string, std::shared_ptr<EquivClassification>> m_equivEncrypt;
+		std::map<std::string, std::shared_ptr<EquivClassification>> m_equivDecrypt;
 	};
 
 }

--- a/include/spiffing/clearance.h
+++ b/include/spiffing/clearance.h
@@ -36,7 +36,7 @@ namespace Spiffing {
 	public:
 		Clearance(std::string const & label, Format fmt);
 		void parse(std::string const & label, Format fmt);
-		void write(Format fmt, std::string &);
+		void write(Format fmt, std::string &) const;
 
 		bool hasClassification(lacv_t lacv) const;
 		std::set<lacv_t> const & classifications() const {
@@ -58,8 +58,8 @@ namespace Spiffing {
 		void parse_xml(std::string const &);
 		void parse_ber(std::string const &);
 		void parse_any(std::string const &);
-		void write_xml(std::string &);
-		void write_ber(std::string &);
+		void write_xml(std::string &) const;
+		void write_ber(std::string &) const;
 
 		std::shared_ptr<Spif> m_policy;
 		std::string m_policy_id;

--- a/include/spiffing/constants.h
+++ b/include/spiffing/constants.h
@@ -80,21 +80,23 @@ namespace Spiffing {
 	class Marking;
 	class CategoryData;
 	class CategoryGroup;
+	class EquivClassification;
+	class EquivCat;
 
     // OID constants
-    namespace OID {
+    struct OID {
         // RBAC / Privilege identifiers
-        std::string const NATO{"2.16.840.1.101.2.1.8.3"}; // ACP-145(A)
-        std::string const MISSI{"2.16.840.1.101.2.1.8.1"};
-        std::string const SSLPrivilege{"2.16.840.1.101.2.1.8.2"};
+        static std::string const NATO; // ACP-145(A)
+		static std::string const MISSI;
+		static std::string const SSLPrivilege;
 
         // ACP-145(A) types
-        std::string const NATO_RestrictiveBitmap{"2.16.840.1.101.2.1.8.3.0"};
-        std::string const NATO_PermissiveBitmap{"2.16.840.1.101.2.1.8.3.2"};
-        std::string const NATO_EnumeratedPermissive{"2.16.840.1.101.2.1.8.3.1"};
-        std::string const NATO_EnumeratedRestrictive{"2.16.840.1.101.2.1.8.3.4"};
-        std::string const NATO_Informative{"2.16.840.1.101.2.1.8.3.3"};
-    }
+		static std::string const NATO_RestrictiveBitmap;
+		static std::string const NATO_PermissiveBitmap;
+		static std::string const NATO_EnumeratedPermissive;
+		static std::string const NATO_EnumeratedRestrictive;
+		static std::string const NATO_Informative;
+    };
 }
 
 #endif

--- a/include/spiffing/equivcat.h
+++ b/include/spiffing/equivcat.h
@@ -23,33 +23,32 @@ SOFTWARE.
 
 ***/
 
-#ifndef SPIFFING_CATREF_H
-#define SPIFFING_CATREF_H
+#ifndef SPIFFING_EQUIVCAT_H
+#define SPIFFING_EQUIVCAT_H
 
 #include <spiffing/constants.h>
-#include <spiffing/category.h>
-#include <memory>
+#include <spiffing/lacv.h>
+#include <spiffing/categoryref.h>
 
 namespace Spiffing {
-  class CategoryRef {
-  public:
-    CategoryRef(std::shared_ptr<Category> const & cat) : m_cat(cat) {}
-    CategoryRef(CategoryRef const & other) : m_cat(other.m_cat) {}
-    CategoryRef(CategoryRef && other) : m_cat(std::move(other.m_cat)) {}
-    Category & operator * () { return *m_cat; }
-    Category const & operator * () const { return *m_cat; }
-    Category * operator -> () { return &*m_cat; }
-    Category const * operator -> () const { return &*m_cat; }
-    bool operator <(CategoryRef const & other) const {
-      return *m_cat < *other;
-    }
-    std::shared_ptr<Category> const & ptr() const {
-      return m_cat;
-    }
+    class EquivCat {
+    public:
+        EquivCat(std::string const & policy_id, std::string const & tagSetId, TagType tagType, Lacv lacv);
+        EquivCat(std::string const & policy_id); // discard
+        void apply(Label &) const;
+        std::string const & policy_id() const {
+            return m_policy_id;
+        }
 
-  private:
-    std::shared_ptr<Category> m_cat;
-  };
+    private:
+        bool m_discard;
+        std::string const m_policy_id;
+        std::string const m_tagSetId;
+        TagType const m_tagType;
+        Lacv const m_lacv;
+        std::shared_ptr<Category> m_cat;
+        void compile(Spif const &);
+    };
 }
 
-#endif
+#endif //SPIFFING_EQUIVCAT_H

--- a/include/spiffing/equivclass.h
+++ b/include/spiffing/equivclass.h
@@ -23,33 +23,30 @@ SOFTWARE.
 
 ***/
 
-#ifndef SPIFFING_CATREF_H
-#define SPIFFING_CATREF_H
+#ifndef SPIFFING_EQUIVCLASS_H
+#define SPIFFING_EQUIVCLASS_H
+
 
 #include <spiffing/constants.h>
-#include <spiffing/category.h>
-#include <memory>
+#include <spiffing/categorygroup.h>
 
 namespace Spiffing {
-  class CategoryRef {
-  public:
-    CategoryRef(std::shared_ptr<Category> const & cat) : m_cat(cat) {}
-    CategoryRef(CategoryRef const & other) : m_cat(other.m_cat) {}
-    CategoryRef(CategoryRef && other) : m_cat(std::move(other.m_cat)) {}
-    Category & operator * () { return *m_cat; }
-    Category const & operator * () const { return *m_cat; }
-    Category * operator -> () { return &*m_cat; }
-    Category const * operator -> () const { return &*m_cat; }
-    bool operator <(CategoryRef const & other) const {
-      return *m_cat < *other;
-    }
-    std::shared_ptr<Category> const & ptr() const {
-      return m_cat;
-    }
-
-  private:
-    std::shared_ptr<Category> m_cat;
-  };
+    class EquivClassification {
+    public:
+        EquivClassification(std::string const & policy_id, lacv_t lacv);
+        void addRequiredCategory(std::unique_ptr<CategoryGroup> && reqCat);
+        void compile();
+        std::unique_ptr<Label> create() const;
+        bool matches(Label const &) const;
+        std::string const & policy_id() const {
+            return m_policy_id;
+        }
+    private:
+        std::string const m_policy_id;
+        std::set<std::unique_ptr<CategoryGroup>> m_reqs;
+        lacv_t m_class;
+    };
 }
 
-#endif
+
+#endif //SPIFFING_EQUIVCLASS_H

--- a/include/spiffing/label.h
+++ b/include/spiffing/label.h
@@ -36,8 +36,9 @@ namespace Spiffing {
 	class Label {
 	public:
 		Label(std::string const & label, Format fmt);
+		Label(std::shared_ptr<Spif> const & policy, lacv_t cls);
 		void parse(std::string const & label, Format fmt);
-		void write(Format fmt, std::string & output);
+		void write(Format fmt, std::string & output) const;
 
 		Classification const & classification() const {
 			return *m_class;
@@ -54,13 +55,15 @@ namespace Spiffing {
 		}
 
 		void addCategory(std::shared_ptr<Category> const & cat);
+
+		std::unique_ptr<Label> encrypt(std::string policy_id) const;
 	private:
 		void parse_ber(std::string const & label);
 		void parse_xml(std::string const & label);
 		void parse_any(std::string const & label);
 
-		void write_ber(std::string &);
-		void write_xml(std::string &);
+		void write_ber(std::string &) const;
+		void write_xml(std::string &) const;
 
 		std::shared_ptr<Spif> m_policy;
 		std::string m_policy_id;

--- a/include/spiffing/spif.h
+++ b/include/spiffing/spif.h
@@ -72,6 +72,7 @@ namespace Spiffing {
 			if (i == m_classifications.end()) throw std::runtime_error("Unknown classification");
 			return (*i).second;
 		}
+		void encrypt(Label &) const;
 
 	private:
 		std::string m_name;
@@ -81,7 +82,9 @@ namespace Spiffing {
 		std::map<lacv_t,std::shared_ptr<Classification>> m_classifications;
 		std::map<std::string /* OID */, std::shared_ptr<TagSet>> m_tagSets;
 		std::map<std::string /* Name */, std::shared_ptr<TagSet>> m_tagSetsByName;
+		std::map<std::string /* Name */, std::string /* OID */> m_equivPolicies;
 		std::unique_ptr<Marking> m_marking;
+		std::multimap<std::string /* OID */, std::unique_ptr<CategoryGroup>> m_equivReqs; /* Required Categories for equivalence */
 	};
 }
 

--- a/include/spiffing/spif.h
+++ b/include/spiffing/spif.h
@@ -61,6 +61,10 @@ namespace Spiffing {
 			return m_rbacId;
 		}
 
+		std::string const & name() const {
+			return m_name;
+		}
+
 		std::shared_ptr<TagSet> const & tagSetLookup(std::string const &) const;
 		std::shared_ptr<TagSet> const & tagSetLookupByName(std::string const &) const;
 		std::shared_ptr<Classification> const & classificationLookup(lacv_t cls) const {

--- a/src/category.cc
+++ b/src/category.cc
@@ -26,9 +26,8 @@ SOFTWARE.
 #include <spiffing/category.h>
 #include <spiffing/classification.h>
 #include <spiffing/tag.h>
-#include <spiffing/categorydata.h>
-#include <spiffing/categorygroup.h>
 #include <spiffing/label.h>
+#include <spiffing/equivcat.h>
 
 using namespace Spiffing;
 
@@ -68,5 +67,18 @@ void Category::compile(Spif const & spif) {
   }
   for (auto & req : m_required) {
     req->compile(spif);
+  }
+}
+
+void Category::encryptEquiv(std::shared_ptr<EquivCat> const & equivCat) {
+  m_encryptEquivs.insert(std::make_pair(equivCat->policy_id(), equivCat));
+}
+
+void Category::encrypt(Label &label, std::string const &policy_id) const {
+  auto i = m_encryptEquivs.lower_bound(policy_id);
+  auto end = m_encryptEquivs.upper_bound(policy_id);
+  if (i == end) throw std::runtime_error("No equivalence to " + m_name);
+  for(; i != end; ++i) {
+    (*i).second->apply(label);
   }
 }

--- a/src/categorydata.cc
+++ b/src/categorydata.cc
@@ -58,3 +58,12 @@ void CategoryData::compile(Spif const & spif) {
     m_cats.insert(tagSet->categoryLookup(m_tagType, m_lacv));
   }
 }
+
+void CategoryData::fixup(Label & l) const {
+  if (m_cats.empty()) {
+    const_cast<CategoryData *>(this)->compile(l.policy());
+  }
+  for (auto & cat : m_cats) {
+    l.addCategory(cat.ptr());
+  }
+}

--- a/src/categorygroup.cc
+++ b/src/categorygroup.cc
@@ -59,3 +59,9 @@ void CategoryGroup::compile(Spif const & spif) {
     cd->compile(spif);
   }
 }
+
+void CategoryGroup::fixup(Label &l) const {
+  for (auto & cd : m_categoryData) {
+    cd->fixup(l);
+  }
+}

--- a/src/classification.cc
+++ b/src/classification.cc
@@ -25,8 +25,8 @@ SOFTWARE.
 
 #include <spiffing/classification.h>
 #include <spiffing/categorygroup.h>
-#include <spiffing/categorydata.h>
-#include <spiffing/marking.h>
+#include <spiffing/equivclass.h>
+#include <spiffing/label.h>
 
 using namespace Spiffing;
 
@@ -38,7 +38,7 @@ bool Classification::operator < (Classification const & c) const {
 	return m_hierarchy < c.m_hierarchy;
 }
 
-void Classification::addRequiredCategory(std::unique_ptr<CategoryGroup> reqCats) {
+void Classification::addRequiredCategory(std::unique_ptr<CategoryGroup> && reqCats) {
 	m_reqCats.insert(std::move(reqCats));
 }
 
@@ -53,4 +53,17 @@ bool Classification::valid(Label const & label) const {
 		if (!req->matches(label)) return false;
 	}
 	return true;
+}
+
+void Classification::equivEncrypt(std::shared_ptr<EquivClassification> const & equiv) {
+	m_equivEncrypt.insert(std::make_pair(equiv->policy_id(), equiv));
+}
+void Classification::equivDecrypt(std::shared_ptr<EquivClassification> const & equiv) {
+	m_equivDecrypt.insert(std::make_pair(equiv->policy_id(), equiv));
+}
+std::unique_ptr<Label> Classification::encrypt(Label const & old, std::string const & policy_id) const {
+	auto i = m_equivEncrypt.find(policy_id);
+	if (i == m_equivEncrypt.end()) throw std::runtime_error("No equivalent classification");
+	auto equiv = (*i).second;
+	return equiv->create();
 }

--- a/src/clearance.cc
+++ b/src/clearance.cc
@@ -67,7 +67,7 @@ void Spiffing::Clearance::parse(std::string const & clearance, Spiffing::Format 
 	}
 }
 
-void Spiffing::Clearance::write(Spiffing::Format fmt, std::string & output) {
+void Spiffing::Clearance::write(Spiffing::Format fmt, std::string & output) const {
 	switch (fmt) {
 	case Spiffing::Format::BER:
 		write_ber(output);
@@ -199,7 +199,7 @@ void Spiffing::Clearance::parse_any(std::string const & clearance) {
 	parse_xml(clearance);
 }
 
-void Spiffing::Clearance::write_xml(std::string & output) {
+void Spiffing::Clearance::write_xml(std::string & output) const {
 	using namespace rapidxml;
 	// Do something sensible.
 	xml_document<> doc;
@@ -247,7 +247,7 @@ void Spiffing::Clearance::write_xml(std::string & output) {
 }
 
 
-void Spiffing::Clearance::write_ber(std::string & output) {
+void Spiffing::Clearance::write_ber(std::string & output) const {
 	Asn<Clearance_t> asn_clearance(&asn_DEF_Clearance);
 	asn_clearance.alloc();
 	Spiffing::Internal::str2oid(m_policy_id, &asn_clearance->policyId);

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -23,33 +23,15 @@ SOFTWARE.
 
 ***/
 
-#ifndef SPIFFING_CATREF_H
-#define SPIFFING_CATREF_H
-
 #include <spiffing/constants.h>
-#include <spiffing/category.h>
-#include <memory>
 
-namespace Spiffing {
-  class CategoryRef {
-  public:
-    CategoryRef(std::shared_ptr<Category> const & cat) : m_cat(cat) {}
-    CategoryRef(CategoryRef const & other) : m_cat(other.m_cat) {}
-    CategoryRef(CategoryRef && other) : m_cat(std::move(other.m_cat)) {}
-    Category & operator * () { return *m_cat; }
-    Category const & operator * () const { return *m_cat; }
-    Category * operator -> () { return &*m_cat; }
-    Category const * operator -> () const { return &*m_cat; }
-    bool operator <(CategoryRef const & other) const {
-      return *m_cat < *other;
-    }
-    std::shared_ptr<Category> const & ptr() const {
-      return m_cat;
-    }
+std::string const Spiffing::OID::NATO = "2.16.840.1.101.2.1.8.3";
+std::string const Spiffing::OID::MISSI{"2.16.840.1.101.2.1.8.1"};
+std::string const Spiffing::OID::SSLPrivilege{"2.16.840.1.101.2.1.8.2"};
 
-  private:
-    std::shared_ptr<Category> m_cat;
-  };
-}
-
-#endif
+// ACP-145(A) types
+std::string const Spiffing::OID::NATO_RestrictiveBitmap{"2.16.840.1.101.2.1.8.3.0"};
+std::string const Spiffing::OID::NATO_PermissiveBitmap{"2.16.840.1.101.2.1.8.3.2"};
+std::string const Spiffing::OID::NATO_EnumeratedPermissive{"2.16.840.1.101.2.1.8.3.1"};
+std::string const Spiffing::OID::NATO_EnumeratedRestrictive{"2.16.840.1.101.2.1.8.3.4"};
+std::string const Spiffing::OID::NATO_Informative{"2.16.840.1.101.2.1.8.3.3"};

--- a/src/equivcat.cc
+++ b/src/equivcat.cc
@@ -23,33 +23,27 @@ SOFTWARE.
 
 ***/
 
-#ifndef SPIFFING_CATREF_H
-#define SPIFFING_CATREF_H
+#include <spiffing/equivcat.h>
+#include <spiffing/label.h>
+#include <spiffing/spif.h>
+#include <spiffing/tagset.h>
 
-#include <spiffing/constants.h>
-#include <spiffing/category.h>
-#include <memory>
+using namespace Spiffing;
 
-namespace Spiffing {
-  class CategoryRef {
-  public:
-    CategoryRef(std::shared_ptr<Category> const & cat) : m_cat(cat) {}
-    CategoryRef(CategoryRef const & other) : m_cat(other.m_cat) {}
-    CategoryRef(CategoryRef && other) : m_cat(std::move(other.m_cat)) {}
-    Category & operator * () { return *m_cat; }
-    Category const & operator * () const { return *m_cat; }
-    Category * operator -> () { return &*m_cat; }
-    Category const * operator -> () const { return &*m_cat; }
-    bool operator <(CategoryRef const & other) const {
-      return *m_cat < *other;
-    }
-    std::shared_ptr<Category> const & ptr() const {
-      return m_cat;
-    }
-
-  private:
-    std::shared_ptr<Category> m_cat;
-  };
+EquivCat::EquivCat(std::string const & policy_id, std::string const & tagSetId, TagType tagType, Lacv lacv)
+    : m_discard(false), m_policy_id(policy_id), m_tagSetId(tagSetId), m_tagType(tagType), m_lacv(lacv) {
 }
 
-#endif
+EquivCat::EquivCat(std::string const & policy_id)
+    : m_discard(true), m_policy_id(policy_id), m_tagType(TagType::informative) {
+}
+
+void EquivCat::apply(Label & label) const {
+    if (m_discard) return;
+    if (!m_cat) const_cast<EquivCat*>(this)->compile(label.policy());
+    label.addCategory(m_cat);
+}
+
+void EquivCat::compile(Spif const & policy) {
+    m_cat = policy.tagSetLookup(m_tagSetId)->categoryLookup(m_tagType, m_lacv);
+}

--- a/src/equivclass.cc
+++ b/src/equivclass.cc
@@ -23,33 +23,25 @@ SOFTWARE.
 
 ***/
 
-#ifndef SPIFFING_CATREF_H
-#define SPIFFING_CATREF_H
+#include <spiffing/spiffing.h>
+#include <spiffing/equivclass.h>
+#include <spiffing/label.h>
 
-#include <spiffing/constants.h>
-#include <spiffing/category.h>
-#include <memory>
+using namespace Spiffing;
 
-namespace Spiffing {
-  class CategoryRef {
-  public:
-    CategoryRef(std::shared_ptr<Category> const & cat) : m_cat(cat) {}
-    CategoryRef(CategoryRef const & other) : m_cat(other.m_cat) {}
-    CategoryRef(CategoryRef && other) : m_cat(std::move(other.m_cat)) {}
-    Category & operator * () { return *m_cat; }
-    Category const & operator * () const { return *m_cat; }
-    Category * operator -> () { return &*m_cat; }
-    Category const * operator -> () const { return &*m_cat; }
-    bool operator <(CategoryRef const & other) const {
-      return *m_cat < *other;
-    }
-    std::shared_ptr<Category> const & ptr() const {
-      return m_cat;
-    }
-
-  private:
-    std::shared_ptr<Category> m_cat;
-  };
+EquivClassification::EquivClassification(std::string const &policy_id, lacv_t lacv)
+    : m_class(lacv), m_policy_id(policy_id) {
 }
 
-#endif
+void EquivClassification::addRequiredCategory(std::unique_ptr<CategoryGroup> &&reqCat) {
+    m_reqs.insert(std::move(reqCat));
+}
+
+std::unique_ptr<Label> EquivClassification::create() const {
+    std::shared_ptr<Spif> spif = Site::site().spif(m_policy_id);
+    std::unique_ptr<Label> label{new Label(spif, m_class)};
+    for (auto & i : m_reqs) {
+        i->fixup(*label);
+    }
+    return label;
+}

--- a/src/spif.cc
+++ b/src/spif.cc
@@ -206,6 +206,10 @@ namespace {
 			cls->addRequiredCategory(parseCategoryGroup(reqCat));
 		}
 		cls->marking(parseMarking(classification));
+		auto color_a = classification->first_attribute("color");
+		if (color_a && color_a->value()) {
+			cls->fgcolour(color_a->value());
+		}
 		return cls;
 	}
 

--- a/src/spif.cc
+++ b/src/spif.cc
@@ -36,6 +36,8 @@ SOFTWARE.
 #include <spiffing/marking.h>
 #include <spiffing/categorydata.h>
 #include <spiffing/categorygroup.h>
+#include <spiffing/equivclass.h>
+#include <spiffing/equivcat.h>
 
 using namespace Spiffing;
 
@@ -167,6 +169,7 @@ namespace {
 	// For requiredCategory
 	std::unique_ptr<CategoryGroup> parseCategoryGroup(rapidxml::xml_node<> * node) {
 		auto op_a = node->first_attribute("operation");
+		if (!op_a || !op_a->value()) throw std::runtime_error("Missing operation attribute from CategoryGroup");
 		std::string opname{op_a->value(), op_a->value_size()};
 		OperationType opType{OperationType::onlyOne};
 		if (opname == "onlyOne") {
@@ -194,7 +197,7 @@ namespace {
 		}
 	}
 
-	std::shared_ptr<Classification> parseClassification(rapidxml::xml_node<> * classification) {
+	std::shared_ptr<Classification> parseClassification(rapidxml::xml_node<> * classification, std::map<std::string,std::string> const & equivPolicies) {
 		auto lacv_a = classification->first_attribute("lacv");
 		lacv_t lacv{strtoull(lacv_a->value(), NULL, 10)};
 		auto name_a = classification->first_attribute("name");
@@ -205,6 +208,27 @@ namespace {
 		for (auto reqCat = classification->first_node("requiredCategory"); reqCat; reqCat = reqCat->next_sibling("requiredCategory")) {
 			cls->addRequiredCategory(parseCategoryGroup(reqCat));
 		}
+		for (auto equivClass = classification->first_node("equivalentClassification"); equivClass; equivClass = equivClass->next_sibling("equivalentClassification")) {
+			auto equivName = equivClass->first_attribute("policyRef");
+			if (!equivName || !equivName->value()) throw std::runtime_error("Equivalent Classification requires policyRef");
+			auto i = equivPolicies.find(equivName->value());
+			if (i == equivPolicies.end()) throw std::runtime_error("PolicyRef not found");
+			auto llacv_a = equivClass->first_attribute("lacv");
+			lacv_t llacv{strtoull(llacv_a->value(), NULL, 10)};
+			auto when_a = equivClass->first_attribute("applied");
+			if (!when_a || !when_a->value()) throw std::runtime_error("Missing applied in equivClass");
+			std::string when{when_a->value()};
+			std::shared_ptr<EquivClassification> equiv{new EquivClassification((*i).second, llacv)};
+			for (auto reqCat = equivClass->first_node("requiredCategory"); reqCat; reqCat = reqCat->next_sibling("requiredCategory")) {
+				equiv->addRequiredCategory(parseCategoryGroup(reqCat));
+			}
+			if (when == "encrypt" || when == "both") {
+				cls->equivEncrypt(equiv);
+			}
+			if (when == "decrypt" || when == "both") {
+				cls->equivDecrypt(equiv);
+			}
+		}
 		cls->marking(parseMarking(classification));
 		auto color_a = classification->first_attribute("color");
 		if (color_a && color_a->value()) {
@@ -213,7 +237,28 @@ namespace {
 		return cls;
 	}
 
-	std::shared_ptr<TagSet> parseTagSet(rapidxml::xml_node<> * tagSet, size_t & ordinal, std::map<std::string,std::shared_ptr<Classification>> const & classNames) {
+	std::shared_ptr<EquivCat> parseEquivCat(rapidxml::xml_node<> * equiv, std::map<std::string,std::string> const & policies) {
+		auto policyref_a = equiv->first_attribute("policyRef");
+		if (!policyref_a || !policyref_a->value()) throw std::runtime_error("Missing PolicyRef");
+		auto i = policies.find(policyref_a->value());
+		if (i == policies.end()) throw std::runtime_error("PolicyRef not found");
+		std::string policy_id = (*i).second;
+		auto tagsetid_a = equiv->first_attribute("tagSetId");
+		if (!tagsetid_a || !tagsetid_a->value()) throw std::runtime_error("Missing tagSetId");
+		TagType tagType = parseTagType(equiv);
+		Lacv lacv = parseLacv(equiv->first_attribute("lacv"));
+		bool discard = (equiv->first_attribute("action") != nullptr);
+		if (discard) {
+			return std::shared_ptr<EquivCat>(new EquivCat(policy_id));
+		} else {
+			return std::shared_ptr<EquivCat>(new EquivCat(policy_id, tagsetid_a->value(), tagType, lacv));
+		}
+	}
+
+	std::shared_ptr<TagSet> parseTagSet(rapidxml::xml_node<> * tagSet,
+										size_t & ordinal,
+										std::map<std::string, std::shared_ptr<Classification>> const & classNames,
+										std::map<std::string,std::string> const & policies) {
 		auto id_a = tagSet->first_attribute("id");
 		auto name_a = tagSet->first_attribute("name");
 		std::shared_ptr<TagSet> ts{new TagSet(id_a->value(), name_a->value())};
@@ -248,6 +293,10 @@ namespace {
 				for (auto excnode = cat->first_node("excludedCategory"); excnode; excnode = excnode->next_sibling("excludedCategory")) {
 					std::unique_ptr<CategoryData> exc = parseOptionalCategoryData(excnode);
 					c->excluded(std::move(exc));
+				}
+				for (auto equiv = cat->first_node("equivalentSecCategoryTag"); equiv; equiv = equiv->next_sibling("equivalentSecCategoryTag")) {
+					std::shared_ptr<EquivCat> ec = parseEquivCat(equiv, policies);
+					c->encryptEquiv(ec);
 				}
 				c->marking(parseMarking(cat));
 			}
@@ -294,10 +343,27 @@ void Spif::parse(std::string const & s, Format fmt) {
 			m_oid = id->value();
 		}
 	}
+	auto equivPolicies = node->first_node("equivalentPolicies");
+	if (equivPolicies) {
+		for (auto equivPolicy = equivPolicies->first_node(
+				"equivalentPolicy"); equivPolicy; equivPolicy = equivPolicy->next_sibling("equivalentPolicy")) {
+			auto name_a = equivPolicy->first_attribute("name");
+			if (!name_a || !name_a->value()) throw std::runtime_error("Equivalent policy requires name");
+			std::string name{name_a->value()};
+			auto id_a = equivPolicy->first_attribute("id");
+			if (!id_a || !id_a->value()) throw std::runtime_error("Equivalent policy requires id");
+			std::string id{id_a->value()};
+			m_equivPolicies.insert(std::make_pair(name, id));
+			for (auto reqCat = equivPolicy->first_node("requiredCategory"); reqCat; reqCat = reqCat->next_sibling(
+					"requiredCategory")) {
+				m_equivReqs.insert(std::make_pair(id, parseCategoryGroup(reqCat)));
+			}
+		}
+	}
 	auto securityClassifications = node->first_node("securityClassifications");
 	std::map<std::string, std::shared_ptr<Classification>> classNames;
 	for (auto classn = securityClassifications->first_node("securityClassification"); classn; classn = classn->next_sibling("securityClassification")) {
-		std::shared_ptr<Classification> c = parseClassification(classn);
+		std::shared_ptr<Classification> c = parseClassification(classn, m_equivPolicies);
 		auto ins = m_classifications.insert(std::make_pair(c->lacv(), c));
 		if (!ins.second) {
 			throw std::runtime_error("Duplicate classification " + c->name());
@@ -311,7 +377,7 @@ void Spif::parse(std::string const & s, Format fmt) {
 	if (securityCategoryTagSets) {
 		size_t ordinal = 0;
 		for (auto tagSet = securityCategoryTagSets->first_node("securityCategoryTagSet"); tagSet; tagSet = tagSet->next_sibling("securityCategoryTagSet")) {
-			std::shared_ptr<TagSet> ts = parseTagSet(tagSet, ordinal, classNames);
+			std::shared_ptr<TagSet> ts = parseTagSet(tagSet, ordinal, classNames, m_equivPolicies);
 			m_tagSets.insert(std::make_pair(ts->id(), ts));
 			m_tagSetsByName.insert(std::make_pair(ts->name(), ts));
 		}
@@ -330,6 +396,7 @@ namespace {
 	void categoryMarkings(MarkingCode loc, std::string & marking, std::set<CategoryRef> const & cats, std::string const & sep) {
 		std::string tagName;
 		std::string tagsep;
+		std::string tagSuffix;
 		for (auto & i : cats) {
 			std::string phrase;
 			if (i->hasMarking()) {
@@ -344,12 +411,15 @@ namespace {
 			if (tagName != currentTagName) {
 				// Entering new tag.
 				tagName = currentTagName;
+				marking += tagSuffix;
 				if (!marking.empty()) marking += sep;
 				if (i->tag().hasMarking()) {
+					tagSuffix = i->tag().marking().suffix();
 					tagsep = i->tag().marking().sep();
 					if (tagsep.empty()) tagsep = "/"; // Default;
 					marking += i->tag().marking().prefix();
 				} else {
+					tagSuffix = "";
 					tagsep = "/";
 				}
 			} else {
@@ -357,6 +427,7 @@ namespace {
 			}
 			marking += phrase;
 		}
+		marking += tagSuffix;
 	}
 }
 
@@ -482,4 +553,11 @@ bool Spif::valid(Label const & label) const {
 		if (!cat->valid(label)) return false;
 	}
 	return true;
+}
+
+void Spif::encrypt(Label & label) const {
+	auto end = m_equivReqs.upper_bound(label.policy_id());
+	for (auto i = m_equivReqs.lower_bound(label.policy_id()); i != end; ++i) {
+		(*i).second->fixup(label);
+	}
 }

--- a/test-data/Makefile
+++ b/test-data/Makefile
@@ -8,16 +8,30 @@ all:
 	$(MAKE) EXECUTOR="$(EXECUTOR)" $(OUTPUTS)
 	rm $(OUTPUTS)
 
-%-nato-out2.ber: %.xml
-	$(EXECUTOR) ../transpifferizer food-policy.xml $< $*-nato-out.ber
-	$(EXECUTOR) ../transpifferizer food-policy.xml $*-nato-out.ber $*-nato-out.xml
-	$(EXECUTOR) ../transpifferizer food-policy.xml $*-nato-out.xml $@
+food-label-%-nato-out2.ber: food-label-%.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml $< $*-nato-out.ber
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml $*-nato-out.ber $*-nato-out.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml $*-nato-out.xml $@
 	diff $@ $*-nato-out.ber
 	rm $*-nato-out.ber $*-nato-out.xml
 
-%-missi-out2.ber: %.xml
-	$(EXECUTOR) ../transpifferizer food-policy-missi.xml $< $*-missi-out.ber
-	$(EXECUTOR) ../transpifferizer food-policy-missi.xml $*-missi-out.ber $*-missi-out.xml
-	$(EXECUTOR) ../transpifferizer food-policy-missi.xml $*-missi-out.xml $@
+food-label-%-missi-out2.ber: food-label-%.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml $< $*-missi-out.ber
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml $*-missi-out.ber $*-missi-out.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml $*-missi-out.xml $@
+	diff $@ $*-missi-out.ber
+	rm $*-missi-out.ber $*-missi-out.xml
+
+food-clearance-%-nato-out2.ber: food-clearance-%.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml -c $< $*-nato-out.ber
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml -c $*-nato-out.ber $*-nato-out.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy.xml -c $*-nato-out.xml $@
+	diff $@ $*-nato-out.ber
+	rm $*-nato-out.ber $*-nato-out.xml
+
+food-clearance-%-missi-out2.ber: food-clearance-%.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml -c $< $*-missi-out.ber
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml -c $*-missi-out.ber $*-missi-out.xml
+	$(EXECUTOR) ../transpifferizer -p food-policy-missi.xml -c $*-missi-out.xml $@
 	diff $@ $*-missi-out.ber
 	rm $*-missi-out.ber $*-missi-out.xml

--- a/test-data/bsi-commercial.xml
+++ b/test-data/bsi-commercial.xml
@@ -1,0 +1,54 @@
+<SPIF xmlns="http://www.xmlspif.org/spif"
+      creationDate="2015-11-11 09:23:00"
+      rbacId="2.16.840.1.101.2.1.8.3"
+      privilegeId="2.16.840.1.101.2.1.8.3"
+      originatorDN="cn=Dave Cridland,o=Survine,c=GB"
+      schemaVersion="2.0"
+      keyIdentifier="">
+    <defaultSecurityPolicyId name="Default" id="1.1"/>
+    <securityPolicyId name="BSI Basic" id="1.2.826.0.1.6726289.0.3"/>
+    <equivalentPolicies>
+        <equivalentPolicy name="TLPX" id="1.2.826.0.1.6726289.0.1"/>
+    </equivalentPolicies>
+    <securityClassifications>
+        <securityClassification name="Public" lacv="20" hierarchy="1">
+            <equivalentClassification policyRef="TLPX" lacv="10" applied="both"/>
+        </securityClassification>
+        <securityClassification name="Sensitive" lacv="21" hierarchy="2">
+            <equivalentClassification policyRef="TLPX" lacv="12" applied="both"/>
+        </securityClassification>
+        <securityClassification name="Private" lacv="22" hierarchy="3">
+            <equivalentClassification policyRef="TLPX" lacv="13" applied="both"/>
+        </securityClassification>
+    </securityClassifications>
+    <securityCategoryTagSets>
+        <securityCategoryTagSet name="Expiry Date" id="1.2.826.0.1.6726289.0.3.0">
+            <securityCategoryTag name="until" tagType="tagType7" tag7Encoding="securityAttributes">
+                <tagCategory name="until" lacv="0" userInput="date"/>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+        <securityCategoryTagSet name="Actions" id="1.2.826.0.1.6726289.0.3.1">
+            <securityCategoryTag tagType="tagType7" tag7Encoding="securityAttributes" name="action">
+                <tagCategory name="Archive" lacv="1">
+                    <requiredCategory>
+                        <categoryGroup tagSetRef="Expiry Date" tagType="tagType7"/>
+                    </requiredCategory>
+                </tagCategory>
+                <tagCategory name="Destroy" lacv="2">
+                    <requiredCategory>
+                        <categoryGroup tagSetRef="Expiry Date" tagType="tagType7"/>
+                    </requiredCategory>
+                </tagCategory>
+                <tagCategory name="Review" lacv="3">
+                    <requiredCategory>
+                        <categoryGroup tagSetRef="Expiry Date" tagType="tagType7"/>
+                    </requiredCategory>
+                </tagCategory>
+                <tagCategory name="Public" lacv="4">
+                    <requiredCategory>
+                        <categoryGroup tagSetRef="Expiry Date" tagType="tagType7"/>
+                    </requiredCategory>
+                </tagCategory>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+    </securityCategoryTagSets>

--- a/test-data/tests.xml
+++ b/test-data/tests.xml
@@ -1,11 +1,22 @@
 <tests>
-  <test spif='food-policy.xml' label='food-label-milk-chocolate.xml' valid='true' clearance='food-clearance-lactose-intolerant.xml' label-marking='[ Sweet/Yummy Chocolate Brown Contains Lactose Not Vegan Animal Rights ]' clearance-marking='[ {Commodity|Luxury} Sweet Contains Peanut+Nut+Gluten Not Vegan ]' acdf-result='0'/>
-  <test spif='food-policy.xml' label='food-label-milk-chocolate.xml' valid='true' clearance='food-clearance-all-okay.xml' acdf-result='1'/>
-  <test spif='food-policy.xml' label='food-label-cheap-milk-chocolate.xml' valid='false'/>
-  <test spif='food-policy.xml' label='food-label-meaty-milk-chocolate.xml' valid='false'/>
-  <test spif='food-policy.xml' label='stupid-label.ber' exception='Unknown policy: 1.1'/>
-  <test spif='food-policy.xml' label='this-file-does-not-exist.ber' exception='No data to parse'/>
-  <test spif='food-policy.xml' label='food-label-bacon.xml' valid='true'/>
-  <test spif='food-policy.xml' label='food-label-water.xml' label-marking='[ FREE British Flag ]' valid='true'/>
-  <test spif='food-policy-borked.xml' label='food-label-bacon.xml' valid='true' exception='Duplicate excluded classification in category'/>
+  <sequence>
+    <policy spif="food-policy.xml"/>
+    <test label='food-label-milk-chocolate.xml' valid='true' clearance='food-clearance-lactose-intolerant.xml' label-marking='[ Sweet/Yummy Chocolate Brown Contains Lactose Not Vegan Animal Rights ]' clearance-marking='[ {Commodity|Luxury} Sweet Contains Peanut+Nut+Gluten Not Vegan ]' acdf-result='0'/>
+    <test label='food-label-milk-chocolate.xml' valid='true' clearance='food-clearance-all-okay.xml' acdf-result='1'/>
+    <test label='food-label-cheap-milk-chocolate.xml' valid='false'/>
+    <test label='food-label-meaty-milk-chocolate.xml' valid='false'/>
+    <test label='stupid-label.ber' exception='Unknown policy: 1.1'/>
+    <test label='this-file-does-not-exist.ber' exception='No data to parse'/>
+    <test label='food-label-bacon.xml' valid='true'/>
+    <test label='food-label-water.xml' label-marking='[ FREE British Flag ]' valid='true'/>
+  </sequence>
+  <sequence>
+    <policy spif='food-policy-borked.xml' exception='Duplicate excluded classification in category'/>
+  </sequence>
+  <sequence>
+    <policy spif="tlp-plus.xml"/>
+    <policy spif="tlp.xml"/>
+    <test label="tlpx-amber-eu.xml" valid="true" label-marking="TLPX:AMBER J:EU" encrypt="1.2.826.0.1.6726289.0.2" encrypt-marking="TLP:AMBER [REGION=EU] [Additional Handling May Apply]/[Imported Data]"/>
+    <test label="tlpx-green-sh-na.xml" valid="true" label-marking="TLPX:GREEN J:SafeHarbour Do not action" encrypt="1.2.826.0.1.6726289.0.2" encrypt-marking="TLP:GREEN [REGION=EU/US] [Imported Data]"/>
+  </sequence>
 </tests>

--- a/test-data/tlp-plus.xml
+++ b/test-data/tlp-plus.xml
@@ -1,0 +1,69 @@
+<SPIF xmlns="http://www.xmlspif.org/spif"
+      creationDate="2015-09-24 09:23:00"
+      rbacId="2.16.840.1.101.2.1.8.3"
+      privilegeId="2.16.840.1.101.2.1.8.3"
+      originatorDN="cn=Dave Cridland,o=Survine,c=GB"
+      schemaVersion="2.0"
+      keyIdentifier="">
+    <defaultSecurityPolicyId name="Default" id="1.1"/>
+    <securityPolicyId name="TLPX" id="1.2.826.0.1.6726289.0.1"/>
+    <equivalentPolicies>
+        <equivalentPolicy name="TLP" id="1.2.826.0.1.6726289.0.2"/>
+    </equivalentPolicies>
+    <securityClassifications>
+        <securityClassification name="WHITE" lacv="10" hierarchy="1" color="white">
+            <equivalentClassification policyRef="TLP" lacv="10" applied="both"/>
+        </securityClassification>
+        <securityClassification name="GREEN" lacv="11" hierarchy="2" color="green">
+            <equivalentClassification policyRef="TLP" lacv="11" applied="both"/>
+        </securityClassification>
+        <securityClassification name="AMBER" lacv="12" hierarchy="3" color="orange">
+            <equivalentClassification policyRef="TLP" lacv="12" applied="both"/>
+        </securityClassification>
+        <securityClassification name="RED" lacv="13" hierarchy="4" color="red">
+            <equivalentClassification policyRef="TLP" lacv="13" applied="both"/>
+        </securityClassification>
+    </securityClassifications>
+    <securityCategoryTagSets>
+        <securityCategoryTagSet name="Jurisdiction" id="1.2.826.0.1.6726289.0.1.1">
+            <securityCategoryTag name='Jurisdiction' tagType="permissive">
+                <tagCategory name="EU" lacv="0"/>
+                <tagCategory name="SafeHarbour" lacv="1"/>
+                <tagCategory name="US" lacv="2"/>
+                <markingQualifier>
+                    <qualifier markingQualifier="," qualifierCode="separator"/>
+                    <qualifier markingQualifier="J:" qualifierCode="prefix"/>
+                </markingQualifier>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+        <securityCategoryTagSet name="Mandatory Data Handling" id="1.2.826.0.1.6726289.0.1.2">
+            <securityCategoryTag name='Handling' tagType="restrictive">
+                <tagCategory name="Anonymize" lacv="0"/>
+                <tagCategory name="Aggregate" lacv="1"/>
+                <markingQualifier>
+                    <qualifier markingQualifier="," qualifierCode="separator"/>
+                    <qualifier markingQualifier="MUST:" qualifierCode="prefix"/>
+                </markingQualifier>
+            </securityCategoryTag>
+            <securityCategoryTag name="Encryption" tagType="restrictive">
+                <tagCategory name="Storage" lacv="2"/>
+                <tagCategory name="Transit" lacv="3"/>
+                <markingQualifier>
+                    <qualifier markingQualifier="," qualifierCode="separator"/>
+                    <qualifier markingQualifier="ENCRYPT:" qualifierCode="prefix"/>
+                </markingQualifier>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+        <securityCategoryTagSet name="Data Status" id="1.2.826.0.1.6726289.0.1.3">
+            <securityCategoryTag name='Actions' tagType="tagType7" tag7Encoding="bitSetAttributes" singleSelection="true">
+                <tagCategory name="Do not action" lacv="0"/>
+                <markingQualifier>
+                    <qualifier markingQualifier="," qualifierCode="separator"/>
+                </markingQualifier>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+    </securityCategoryTagSets>
+    <markingQualifier>
+        <qualifier markingQualifier="TLP:" qualifierCode="prefix"/>
+    </markingQualifier>
+</SPIF>

--- a/test-data/tlp-plus.xml
+++ b/test-data/tlp-plus.xml
@@ -8,7 +8,11 @@
     <defaultSecurityPolicyId name="Default" id="1.1"/>
     <securityPolicyId name="TLPX" id="1.2.826.0.1.6726289.0.1"/>
     <equivalentPolicies>
-        <equivalentPolicy name="TLP" id="1.2.826.0.1.6726289.0.2"/>
+        <equivalentPolicy name="TLP" id="1.2.826.0.1.6726289.0.2">
+            <requiredCategory operation="all">
+                <categoryGroup tagSetRef="Additional Information" tagType="tagType7" lacv="1"/>
+            </requiredCategory>
+        </equivalentPolicy>
     </equivalentPolicies>
     <securityClassifications>
         <securityClassification name="WHITE" lacv="10" hierarchy="1" color="white">
@@ -18,7 +22,11 @@
             <equivalentClassification policyRef="TLP" lacv="11" applied="both"/>
         </securityClassification>
         <securityClassification name="AMBER" lacv="12" hierarchy="3" color="orange">
-            <equivalentClassification policyRef="TLP" lacv="12" applied="both"/>
+            <equivalentClassification policyRef="TLP" lacv="12" applied="both">
+                <requiredCategory operation="all">
+                    <categoryGroup tagSetRef="Additional Information" tagType="tagType7" lacv="0"/>
+                </requiredCategory>
+            </equivalentClassification>
         </securityClassification>
         <securityClassification name="RED" lacv="13" hierarchy="4" color="red">
             <equivalentClassification policyRef="TLP" lacv="13" applied="both"/>
@@ -27,9 +35,16 @@
     <securityCategoryTagSets>
         <securityCategoryTagSet name="Jurisdiction" id="1.2.826.0.1.6726289.0.1.1">
             <securityCategoryTag name='Jurisdiction' tagType="permissive">
-                <tagCategory name="EU" lacv="0"/>
-                <tagCategory name="SafeHarbour" lacv="1"/>
-                <tagCategory name="US" lacv="2"/>
+                <tagCategory name="EU" lacv="0">
+                    <equivalentSecCategoryTag policyRef="TLP" tagSetId="1.2.826.0.1.6726289.0.2.1" tagType="permissive" lacv="0" applied="encrypt"/>
+                </tagCategory>
+                <tagCategory name="SafeHarbour" lacv="1">
+                    <equivalentSecCategoryTag policyRef="TLP" tagSetId="1.2.826.0.1.6726289.0.2.1" tagType="permissive" lacv="0" applied="encrypt"/>
+                    <equivalentSecCategoryTag policyRef="TLP" tagSetId="1.2.826.0.1.6726289.0.2.1" tagType="permissive" lacv="1" applied="encrypt"/>
+                </tagCategory>
+                <tagCategory name="US" lacv="2">
+                    <equivalentSecCategoryTag policyRef="TLP" tagSetId="1.2.826.0.1.6726289.0.2.1" tagType="permissive" lacv="1" applied="encrypt"/>
+                </tagCategory>
                 <markingQualifier>
                     <qualifier markingQualifier="," qualifierCode="separator"/>
                     <qualifier markingQualifier="J:" qualifierCode="prefix"/>
@@ -56,7 +71,9 @@
         </securityCategoryTagSet>
         <securityCategoryTagSet name="Data Status" id="1.2.826.0.1.6726289.0.1.3">
             <securityCategoryTag name='Actions' tagType="tagType7" tag7Encoding="bitSetAttributes" singleSelection="true">
-                <tagCategory name="Do not action" lacv="0"/>
+                <tagCategory name="Do not action" lacv="0">
+                    <equivalentSecCategoryTag policyRef="TLP" tagSetId="1.2.826.0.1.6726289.0.2.1" tagType="tagType7" lacv="" applied="encrypt" action="discard"/>
+                </tagCategory>
                 <markingQualifier>
                     <qualifier markingQualifier="," qualifierCode="separator"/>
                 </markingQualifier>
@@ -64,6 +81,6 @@
         </securityCategoryTagSet>
     </securityCategoryTagSets>
     <markingQualifier>
-        <qualifier markingQualifier="TLP:" qualifierCode="prefix"/>
+        <qualifier markingQualifier="TLPX:" qualifierCode="prefix"/>
     </markingQualifier>
 </SPIF>

--- a/test-data/tlp.xml
+++ b/test-data/tlp.xml
@@ -1,0 +1,55 @@
+<SPIF xmlns="http://www.xmlspif.org/spif"
+      creationDate="2015-09-24 09:23:00"
+      rbacId="2.16.840.1.101.2.1.8.3"
+      privilegeId="2.16.840.1.101.2.1.8.3"
+      originatorDN="cn=Dave Cridland,o=Survine,c=GB"
+      schemaVersion="2.0"
+      keyIdentifier="">
+    <defaultSecurityPolicyId name="Default" id="1.1"/>
+    <securityPolicyId name="TLP" id="1.2.826.0.1.6726289.0.2"/>
+    <equivalentPolicies>
+        <equivalentPolicy name="TLPX" id="1.2.826.0.1.6726289.0.1"/>
+    </equivalentPolicies>
+    <securityClassifications>
+        <securityClassification name="WHITE" lacv="10" hierarchy="1" color="white">
+            <equivalentClassification policyRef="TLPX" lacv="10" applied="both"/>
+        </securityClassification>
+        <securityClassification name="GREEN" lacv="11" hierarchy="2" color="green">
+            <equivalentClassification policyRef="TLPX" lacv="11" applied="both"/>
+        </securityClassification>
+        <securityClassification name="AMBER" lacv="12" hierarchy="3" color="orange">
+            <equivalentClassification policyRef="TLPX" lacv="12" applied="both"/>
+        </securityClassification>
+        <securityClassification name="RED" lacv="13" hierarchy="4" color="red">
+            <equivalentClassification policyRef="TLPX" lacv="13" applied="both"/>
+        </securityClassification>
+    </securityClassifications>
+    <securityCategoryTagSets>
+        <securityCategoryTagSet name="Additional Information" id="1.2.826.0.1.6726289.0.2.1">
+            <securityCategoryTag name='Regions' tagType="permissive">
+                <tagCategory name="EU" lacv="0"/>
+                <tagCategory name="US" lacv="1"/>
+                <markingQualifier>
+                    <qualifier markingQualifier="/" qualifierCode="separator"/>
+                    <qualifier markingQualifier="[REGION=" qualifierCode="prefix"/>
+                    <qualifier markingQualifier="]" qualifierCode="suffix"/>
+                </markingQualifier>
+            </securityCategoryTag>
+            <securityCategoryTag name="Extra Warning" tagType="tagType7" tag7Encoding="bitSetAttributes">
+                <tagCategory name="Extra" lacv="0">
+                    <markingData phrase="[Additional Handling May Apply]">
+                        <code>pageTopBottom</code>
+                    </markingData>
+                </tagCategory>
+                <tagCategory name="Foreign" lacv="1">
+                    <markingData phrase="[Imported Data]">
+                        <code>pageTopBottom</code>
+                    </markingData>
+                </tagCategory>
+            </securityCategoryTag>
+        </securityCategoryTagSet>
+    </securityCategoryTagSets>
+    <markingQualifier>
+        <qualifier markingQualifier="TLP:" qualifierCode="prefix"/>
+    </markingQualifier>
+</SPIF>

--- a/test-data/tlpx-amber-eu.xml
+++ b/test-data/tlpx-amber-eu.xml
@@ -1,0 +1,5 @@
+<label xmlns='http://surevine.com/xmlns/spiffy'>
+    <policy id='1.2.826.0.1.6726289.0.1'/>
+    <classification lacv='12'/>
+    <tag type='permissive' id='1.2.826.0.1.6726289.0.1.1' lacv='0'/>
+</label>

--- a/test-data/tlpx-green-sh-na.xml
+++ b/test-data/tlpx-green-sh-na.xml
@@ -1,6 +1,6 @@
 <label xmlns='http://surevine.com/xmlns/spiffy'>
     <policy id='1.2.826.0.1.6726289.0.1'/>
     <classification lacv='11'/>
-    <tag type='permissive' id='1.2.826.0.1.6726289.0.1.1' lacv='2'/>
+    <tag type='permissive' id='1.2.826.0.1.6726289.0.1.1' lacv='1'/>
     <tag type="informative" id="1.2.826.0.1.6726289.0.1.3" lacv="0"/>
 </label>

--- a/test-data/tlpx-green-us-na.xml
+++ b/test-data/tlpx-green-us-na.xml
@@ -1,0 +1,6 @@
+<label xmlns='http://surevine.com/xmlns/spiffy'>
+    <policy id='1.2.826.0.1.6726289.0.1'/>
+    <classification lacv='11'/>
+    <tag type='permissive' id='1.2.826.0.1.6726289.0.1.1' lacv='2'/>
+    <tag type="informative" id="1.2.826.0.1.6726289.0.1.3" lacv="0"/>
+</label>

--- a/test.cc
+++ b/test.cc
@@ -34,31 +34,35 @@ SOFTWARE.
 bool test_step(std::size_t testno, rapidxml::xml_node<> * test) {
 	using namespace Spiffing;
 	try {
-		std::ifstream spiffile(test->first_attribute("spif")->value());
-		Site site;
-		auto spif = site.load(spiffile);
 		std::ifstream label_file(test->first_attribute("label")->value());
 		std::string label_str{std::istreambuf_iterator<char>(label_file), std::istreambuf_iterator<char>()};
-		Label label(label_str, Format::ANY);
+		std::unique_ptr<Label> label(new Label(label_str, Format::ANY));
 		if (test->first_attribute("valid")) {
-			bool result = spif->valid(label);
+			bool result = label->policy().valid(*label);
 			bool expected = (test->first_attribute("valid")->value()[0] == 't');
 			if (result != expected) throw std::runtime_error(std::string("Validity failure: Expected ") + (expected ? "VALID" : "NOT valid"));
 		}
 		if (test->first_attribute("label-marking")) {
-			std::string label_marking = spif->displayMarking(label);
+			std::string label_marking = label->policy().displayMarking(*label);
 			if (label_marking != test->first_attribute("label-marking")->value()) throw std::runtime_error("Mismatching label marking: " + label_marking);
+		}
+		if (test->first_attribute("encrypt")) {
+			label = label->encrypt(test->first_attribute("encrypt")->value());
+		}
+		if (test->first_attribute("encrypt-marking")) {
+			std::string label_marking = label->policy().displayMarking(*label);
+			if (label_marking != test->first_attribute("encrypt-marking")->value()) throw std::runtime_error("Mismatching encrypt-label marking: " + label_marking);
 		}
 		if (test->first_attribute("clearance")) {
 			std::ifstream clearance_file(test->first_attribute("clearance")->value());
 			std::string clearance_str{std::istreambuf_iterator<char>(clearance_file), std::istreambuf_iterator<char>()};
 			Clearance clearance(clearance_str, Format::ANY);
 			if(test->first_attribute("clearance-marking")) {
-				std::string clearance_marking = spif->displayMarking(clearance);
+				std::string clearance_marking = clearance.policy().displayMarking(clearance);
 				if (clearance_marking != test->first_attribute("clearance-marking")->value()) throw std::runtime_error("Mismatching clearance marking: " + clearance_marking);
 			}
 			bool acdf = (test->first_attribute("acdf-result")->value()[0] == '1');
-			if (acdf != spif->acdf(label, clearance)) throw std::runtime_error(std::string("ACDF result is unexpected ") + (acdf ? "FAIL" : "PASS"));
+			if (acdf != clearance.policy().acdf(*label, clearance)) throw std::runtime_error(std::string("ACDF result is unexpected ") + (acdf ? "FAIL" : "PASS"));
 		}
 		auto ex = test->first_attribute("exception");
 		if (ex) {
@@ -89,10 +93,31 @@ int main(int argc, char *argv[]) {
 		std::size_t testno = 0;
 		std::size_t passes = 0;
 		std::cout << "Tests initiaterizing." << std::endl;
-		for (auto test = root->first_node("test"); test; test = test->next_sibling("test")) {
-			++testno;
-			if (test_step(testno, test)) {
-				++passes;
+		for (auto seq = root->first_node("sequence"); seq; seq = seq->next_sibling("sequence")) {
+			Spiffing::Site site;
+			for (auto pol = seq->first_node("policy"); pol; pol = pol->next_sibling("policy")) {
+				try {
+					++testno;
+					auto spif = pol->first_attribute("spif");
+					std::ifstream spiffile{spif->value()};
+					site.load(spiffile);
+					auto ex = pol->first_attribute("exception");
+					if (ex) throw std::runtime_error("Expected exception " + std::string(ex->value()));
+					++passes;
+				} catch(std::exception &e) {
+					auto ex = pol->first_attribute("exception");
+					if (ex && std::string(ex->value()) == e.what()) {
+						++passes;
+						continue;
+					} // Expected this error; pass.
+					std::cout << "Policy load at " << testno << " failed: " << e.what() << std::endl;
+				}
+			}
+			for (auto test = seq->first_node("test"); test; test = test->next_sibling("test")) {
+				++testno;
+				if (test_step(testno, test)) {
+					++passes;
+				}
 			}
 		}
 		std::cout << "[" << passes << "/" << testno << "] Tests passed." << std::endl;


### PR DESCRIPTION
This adds support for translating labels from a local policy to a remote one, known as encrypt mode.
    
Both source and target policy files must be loaded into the Site object for this to work, and the source policy needs to have the equivalent policy data present.
    
Spiffing aims to support the full range of XML SPIF 2.0.
